### PR TITLE
Another api

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -25,7 +25,6 @@ MutatingOrNot = "0.1, 0.2"
 PackageExtensionCompat = "1"
 UnicodePlots = "3.8.1"
 Zygote = "0.6.77"
-julia = "1.8"
 
 [extras]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"

--- a/Project.toml
+++ b/Project.toml
@@ -4,8 +4,12 @@ authors = ["The ClimFlows contributors"]
 version = "0.3.9"
 
 [deps]
+Enzyme = "7da242da-08ed-463a-9acd-ee780be4f1d9"
+ForwardDiff = "f6369f11-7733-5829-9624-2563aa707210"
 MutatingOrNot = "6a37069a-9a67-4b2d-a34a-f09ab4b23c7c"
 PackageExtensionCompat = "65ce6f38-6b18-4e1d-a461-8949797d7930"
+UnicodePlots = "b8865327-cd53-5732-bb35-84acbb429228"
+Zygote = "e88e6eb3-aa80-5325-afca-941959d7151f"
 
 [weakdeps]
 Adapt = "79e6a3ab-5dfb-504d-930d-738a2a938a0e"
@@ -15,8 +19,12 @@ Adapt_Ext = "Adapt"
 
 [compat]
 Adapt = "4"
+Enzyme = "0.13.129"
+ForwardDiff = "1.3.2"
 MutatingOrNot = "0.1, 0.2"
 PackageExtensionCompat = "1"
+UnicodePlots = "3.8.1"
+Zygote = "0.6.77"
 julia = "1.8"
 
 [extras]

--- a/src/CFTimeSchemes.jl
+++ b/src/CFTimeSchemes.jl
@@ -104,6 +104,7 @@ include("julia/update.jl")
 include("julia/explicit.jl")
 include("julia/implicit.jl")
 include("julia/imex.jl")
+include("julia/another_api.jl")
 
 # Initial-value problem solver
 """

--- a/src/julia/another_api.jl
+++ b/src/julia/another_api.jl
@@ -1,0 +1,168 @@
+abstract type MODEL{S} end
+abstract type TIMESCHEME{M,S} end
+
+struct RK3{M<:MODEL,S}<:TIMESCHEME{M,S}
+    dq1::S
+    dq2::S
+    dq3::S
+    model::M
+end
+
+struct RK4{M<:MODEL,S}<:TIMESCHEME{M,S}
+    dq1::S
+    dq2::S
+    dq3::S
+    dq4::S
+    model::M
+end
+
+" RK3{M,S} is a struct of the SSP RK3 time stepping
+
+  RK3 depends on the model (type `M<:MODEL`) and its state (type `S`)
+  Once create, it can be used to perform the update the state.
+
+Usage:
+
+julia> scheme = RK3(model, state)
+
+julia> advance!(state, dt, scheme)
+"
+function RK3(model::M, state::S) where {M<:MODEL,S}
+    RK3{M,S}([similar(state) for _ in 1:3]..., model)
+end
+
+" RK4{M,S} is a struct of the classical RK4 time stepping
+
+  its API is like RK3"
+function RK4(model::M, state::S) where {M<:MODEL,S}
+    RK4{M,S}([similar(state) for _ in 1:4]..., model)
+end
+
+" `advance!(state,h,scheme)`
+
+update the model `state` by one time step `h` using the time `scheme`"
+function advance!(state::S, h, scheme::T) where {M<:MODEL,S,T<:TIMESCHEME{M,S}} end
+
+
+Base.show(io::IO, scheme::T) where {S,M<:MODEL{S},T<:TIMESCHEME{M,S}} = begin
+    print(io, "Time scheme $(nameof(T)) of model $(nameof(M))")
+end
+
+
+" `rhs!(dq,q,model::M,stage) where {M<:MODEL}`
+
+computes the right-hand side `dq` of `model` using the state `q`
+
+`stage` indicates the call rank during the time iteration, `stage` = 1,2,...,0
+the first stage is 1, the last stage is 0. This allows `rhs!` to be aware of the last call.
+
+`rhs!` must be defined for each model `M`."
+function rhs!(dq::S,q::S,model::M,stage) where {M<:MODEL,S} end
+
+" `projection!(q,model::M,stage)`
+
+correct the `model` state `q`, once the tendency has been added
+
+This is where implicit terms, e.g. vertical mixing, or constraints, e.g. pressure projection, are computed.
+
+For a model `M`, `projection!` can be ignored if no such computation is necessary.
+"
+function projection!(q::S,model::M,stage) where {M<:MODEL,S} end
+
+
+# The general idea is to store the model state in the form of NamedTuple of arrays
+STATE = NamedTuple{names, <:Tuple{Vararg{Array}}} where names
+# from https://discourse.julialang.org/t/tuple-and-namedtuple-types/73701
+# Question 2: for named tuples it’s trickier because they are not
+# covariant, but since the types are encoded with a tuple (which is
+# covariant) it’s still easy to do:
+
+# This requires to extend Base.similar
+Base.similar(state::NamedTuple) = begin
+    names = typeof(state).parameters[1]
+    NamedTuple{names}((similar(state[name]) for name in names))
+end
+
+# and to have a way add linear combinations of tendencies and coefficients to the model state
+update!(q::S,(dq1,c1)::R) where {T,S<:STATE,R<:Tuple{S,T}} = begin
+    for k in keys(q)
+        @. q[k] += c1*dq1[k]
+    end
+end
+update!(q::S,(dq1,c1)::R,(dq2,c2)::R) where {T,S<:STATE,R<:Tuple{S,T}} = begin
+    for k in keys(q)
+        @. q[k] += c1*dq1[k]+c2*dq2[k]
+    end
+end
+update!(q::S,(dq1,c1)::R,(dq2,c2)::R,(dq3,c3)::R) where {T,S<:STATE,R<:Tuple{S,T}} = begin
+    for k in keys(q)
+        @. q[k] += c1*dq1[k]+c2*dq2[k]+c3*dq3[k]
+    end
+end
+update!(q::S,(dq1,c1)::R,(dq2,c2)::R,(dq3,c3)::R,(dq4,c4)::R) where {T,S<:STATE,R<:Tuple{S,T}} = begin
+    for k in keys(q)
+        @. q[k] += c1*dq1[k]+c2*dq2[k]+c3*dq3[k]+c4*dq4[k]
+    end
+end
+
+# The basic case is when state is simply an array
+update!(q::S,(dq1,c1)::R) where {T,S<:Array,R<:Tuple{S,T}} = begin
+    @. q += c1*dq1
+end
+update!(q::S,(dq1,c1)::R,(dq2,c2)::R) where {T,S<:Array,R<:Tuple{S,T}} = begin
+    @. q += c1*dq1+c2*dq2
+end
+update!(q::S,(dq1,c1)::R,(dq2,c2)::R,(dq3,c3)::R) where {T,S<:Array,R<:Tuple{S,T}} = begin
+    @. q += c1*dq1+c2*dq2+c3*dq3
+end
+update!(q::S,(dq1,c1)::R,(dq2,c2)::R,(dq3,c3)::R,(dq4,c4)::R) where {T,S<:Array,R<:Tuple{S,T}} = begin
+    @. q += c1*dq1+c2*dq2+c3*dq3+c4*dq4
+end
+
+
+function advance!(q::S, h, rk3::RK3{M,S}) where {M<:MODEL,S}
+    (;dq1,dq2,dq3,model) = rk3
+
+    stage = 1
+    rhs!(dq1,q,model,stage)
+    update!(q,(dq1,h))
+    projection!(q,model,stage)
+
+    stage = 2
+    rhs!(dq2,q,model,stage)
+    update!(q,(dq1,-3h/4),(dq2,h/4))
+    projection!(q,model,stage)
+
+    stage = 0
+    rhs!(dq3,q,model,stage)
+    update!(q,(dq1,-h/12),(dq2,-h/12),(dq3,2h/3))
+    projection!(q,model,stage)
+    return q
+end
+
+
+function advance!(q::S, h, rk4::RK4{M,S}) where {M<:MODEL,S}
+    (;dq1,dq2,dq3,dq4,model) = rk4
+
+    stage = 1
+    rhs!(dq1,q,model,stage)
+    update!(q,(dq1,h/2))
+    projection!(q,model,stage)
+
+    stage = 2
+    rhs!(dq2,q,model,stage)
+    update!(q,(dq1,-h/2),(dq2,h/2))
+    projection!(q,model,stage)
+
+    stage = 3
+    rhs!(dq3,q,model,stage)
+    update!(q,(dq2,-h/2),(dq3,h/1))
+    projection!(q,model,stage)
+
+    stage = 0
+    rhs!(dq4,q,model,stage)
+    update!(q,(dq1,h/6),(dq2,h/3),(dq3,-2h/3),(dq4,h/6))
+    projection!(q,model,stage)
+
+    return q
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,9 +154,12 @@ Schemes = [RungeKutta4, KinnmarkGray{2,5}, KinnmarkGray{3,5},
 @testset "Accuracy" begin
     foreach(stability_region, Schemes)
     println()
-end
+# end
 
 @testset "Auto-diff" begin
     foreach(autodiff, Schemes)
     println()
 end
+
+include("test_another_api.jl")
+

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -154,7 +154,7 @@ Schemes = [RungeKutta4, KinnmarkGray{2,5}, KinnmarkGray{3,5},
 @testset "Accuracy" begin
     foreach(stability_region, Schemes)
     println()
-# end
+end
 
 @testset "Auto-diff" begin
     foreach(autodiff, Schemes)

--- a/test/test_another_api.jl
+++ b/test/test_another_api.jl
@@ -49,10 +49,6 @@ function test_foo()
     end
 end
 
-if false
-    test_foo()
-end
-
 # Second tests on the Lorenz model
 
 struct Lorenz{S,T}<:MODEL{S} where T

--- a/test/test_another_api.jl
+++ b/test/test_another_api.jl
@@ -1,0 +1,101 @@
+using CFTimeSchemes: MODEL, projection!, advance!, RK3, RK4, STATE
+using CFTimeSchemes
+
+# First tests on a FOO model
+
+struct FOO{S}<:MODEL{S}
+    state::S
+end
+
+Foo(n) = FOO((;u=zeros(n)))
+
+
+function CFTimeSchemes.rhs!(dq::S,q::S,model::FOO{S},stage) where {S}
+    @. dq.u = stage
+end
+
+function CFTimeSchemes.projection!(q::S,model::FOO{S},stage) where {S}
+    @. q.u = stage
+end
+
+function test_foo_scheme(model, timescheme)
+    (;state) = model
+    scheme = timescheme(model,state)
+    dt = 1.0
+    advance!(state,dt,scheme)
+
+    @test all(@. scheme.dq1.u == 1)
+    @test all(@. scheme.dq2.u == 2)
+    @test all(@. state.u == 0)
+    if timescheme == RK3
+        @test all(@. scheme.dq3.u == 0)
+    elseif timescheme == RK4
+        @test all(@. scheme.dq3.u == 3)
+        @test all(@. scheme.dq4.u == 0)
+    end
+
+end
+
+function test_foo()
+    n=5
+    model = Foo(n)
+    state = model.state
+    @test state isa STATE
+    @test keys(similar(state)) == (:u,)
+    @test length(similar(state).u) == n
+
+    for timescheme in [RK3, RK4]
+        test_foo_scheme(model,timescheme)
+    end
+end
+
+if false
+    test_foo()
+end
+
+# Second tests on the Lorenz model
+
+struct Lorenz{S,T}<:MODEL{S} where T
+    state:: S
+    sigma::T
+    rho::T
+    beta::T
+end
+
+function CFTimeSchemes.rhs!(dq::S,q::S,(;sigma,rho,beta)::Lorenz{S},stage) where {S}
+    x,y,z = q
+    dx = sigma*(y-x)
+    dy = x*(rho-z)-y
+    dz = x*y-beta*z
+    @. dq = dx,dy,dz
+end
+
+
+function test_lorenz_scheme(TS)
+    (;state) = model = Lorenz(zeros(3), 10.0,28.0,8/3)
+    scheme = TS(model,state)
+    run(n) = begin
+        for _ in 1:n
+            advance!(state,dt,scheme)
+        end
+    end
+
+    state[:] = [0,3,0]
+    dt = 0.02
+    run(10)
+    if TS == RK3
+        @test all(state .== [8.804272893448221, 18.251042040845917, 6.4657089552738105])
+    elseif TS == RK4
+        @test all(state .== [8.810586052614886, 18.258247900759972, 6.4820051132423810])
+    end
+end
+
+function test_lorenz()
+    test_lorenz_scheme(RK3)
+    test_lorenz_scheme(RK4)
+end
+
+@testset "Another API" begin
+    test_foo()
+    test_lorenz()
+end


### PR DESCRIPTION
Another API for timescheme: no concept of scratch. Instead, tendencies are stored in a struct. Each timescheme has its own struct. So far RK3 (SSP) and RK4.

After each stage (call to the rhs + update) a `projection!` is called, that directly correct the state. This is typically where we put pressure correction, barotropic correction (for ocean HPE models) or implicity vertical mixing.